### PR TITLE
Permit 'tel' protocol urls in href attributes

### DIFF
--- a/HTMLPurifier.js
+++ b/HTMLPurifier.js
@@ -124,7 +124,7 @@ var htmlPurifier = function(settings){
                     if (name === 'href') {
                         // don't allow links to anywhere other than http(s)
                         // because they could contain JavaScript (javascript:) or other bad things!
-                        var permittedRegex = /(?:^https?:\/\/)|(?:^\/[^:\\;\(\)"']*$)|(?:^s?ftps?:\/\/)|(?:^#[^\/]*)|(?:^mailto:)/i;
+                        var permittedRegex = /(?:^https?:\/\/)|(?:^\/[^:\\;\(\)"']*$)|(?:^s?ftps?:\/\/)|(?:^#[^\/]*)|(?:^mailto:)|(?:^tel:)/i;
                         if (!permittedRegex.test(value) || /script:/.test(value)) {
                             // if not allowed, set the attribute to be empty
                             value = '';


### PR DESCRIPTION
Hi, thanks for the HTML purifier. I had a requirement to permit 'tel' protocol urls in href attributes for use in a mobile app that uses Meteor as its backend. Best regards, Hans 